### PR TITLE
Add .import folder to .gitattributes export-ignore

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,7 @@
 /.github export-ignore
 /.gitignore export-ignore
 /.gitattributes export-ignore
+/.import export-ignore
 /test export-ignore
 /project.godot export-ignore
 /default_env.tres export-ignore


### PR DESCRIPTION
I see that this repository has a `.import` folder, and an explanation for why it exists in the `.gitignore` (for CI).

However, we don't want to distribute this folder to users, as it adds to the download size and is easily regenerated. This PR adds it to the `.gitattributes` file with `export-ignore`.